### PR TITLE
ci: add action for publish docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+
+name: publish-docker-image
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  build_and_push_to_docker_hub:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push frontend to Docker Hub web
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: avor0n/kardo-mobile-app-front:latest
+          context: .
+          file: dockerfile


### PR DESCRIPTION
Добавил gh-action, который будет автоматически публиковать докер-образ в докерхаб при влитии PR-в ветку `main`